### PR TITLE
[FIX] Replaced instances of 'localhost' with '127.0.0.1' in order to match new Spotify API security requirements - without this, the usual workflow won't run

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Fetch the release for your platform [from the following page](https://github.com
 
 ## Setup
 
-Use the `baton auth` command to perform an initial setup. The command will take you through the process but you will need to login to the [Spotify API dashboard](https://beta.developer.spotify.com/dashboard/login), create an app, and set it up with a redirect URL of http://localhost:15298/callback.
+Use the `baton auth` command to perform an initial setup. The command will take you through the process but you will need to login to the [Spotify API dashboard](https://beta.developer.spotify.com/dashboard/login), create an app, and set it up with a redirect URL of http://127.0.0.1:15298/callback.
 
 This process will generate a long-lasting refresh token and ideally will never have to be repeated.
 

--- a/api/account.go
+++ b/api/account.go
@@ -31,7 +31,7 @@ func GetAuthorizationURL(id string) string {
 	v := url.Values{}
 	v.Set("client_id", id)
 	v.Set("response_type", "code")
-	v.Set("redirect_uri", "http://localhost:15298/callback")
+	v.Set("redirect_uri", "http://127.0.0.1:15298/callback")
 	v.Set("scope", "playlist-read-private user-top-read user-library-read user-library-modify user-read-currently-playing user-read-recently-played user-modify-playback-state user-read-playback-state user-follow-read playlist-read-collaborative")
 
 	r := buildRequest("GET", accountsURLBase+"authorize", v, nil)
@@ -44,7 +44,7 @@ func AuthorizeWithCode(id, secret, code string) {
 	v := url.Values{}
 	v.Set("grant_type", "authorization_code")
 	v.Set("code", code)
-	v.Set("redirect_uri", "http://localhost:15298/callback")
+	v.Set("redirect_uri", "http://127.0.0.1:15298/callback")
 
 	r := buildRequest("POST", accountsURLBase+"api/token", v, nil)
 	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -96,3 +96,5 @@ var authCmd = &cobra.Command{
 	Run:     authenticate,
 	Aliases: []string{"authenticate"},
 }
+
+// Comment test for pull requests

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -21,7 +21,7 @@ func getClientCredentials() (id, secret string) {
 		"3. Create a new app\n" +
 		"4. Click the newly created app\n" +
 		"5. Click 'Edit Settings'\n" +
-		"6. Add 'http://localhost:15298/callback' as a redirect URI, don't forget to save\n" +
+		"6. Add 'http://127.0.0.1:15298/callback' as a redirect URI, don't forget to save\n" +
 		"7. Copy the Client Id and Client Secret\n" +
 		"8. Input the items as the CLI asks for them\n")
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -96,5 +96,3 @@ var authCmd = &cobra.Command{
 	Run:     authenticate,
 	Aliases: []string{"authenticate"},
 }
-
-// Comment test for pull requests


### PR DESCRIPTION
## Description
Spotify does not allow you to use localhost on their dev API any more.
If you try to use 127.0.0.1 instead, baton fails the handshake that connects it to the API.
Replacing baton's references to localhost fixes this problem and makes baton auth function as normal again.
